### PR TITLE
Bug: make curation validation less strict

### DIFF
--- a/ualrdm-directory-validation/directory-validate.py
+++ b/ualrdm-directory-validation/directory-validate.py
@@ -72,10 +72,10 @@ def main():
         schema_dict = load_yaml(data)
     except Exception as e:
         print("Could not load schema file: {0}".format(e))
-        return(1)
+        return 1
     except SchemaError:
         print("Provided document is not valid JSON or YAML Schema")
-        return(2)
+        return 2
 
     print()
     print("Validation Results")
@@ -86,7 +86,7 @@ def main():
     except Exception as e:
         print("Error: {0}".format(e))
 
-    return(0)
+    return 0
 
 
 def _dir_to_list(path, i=0):

--- a/ualrdm-directory-validation/ualrdm-curationdirectory-schema.json
+++ b/ualrdm-directory-validation/ualrdm-curationdirectory-schema.json
@@ -34,36 +34,6 @@
                       },
                       "name": {
                         "pattern": "^METADATA$"
-                      },
-                      "contents": {
-                        "type": "array",
-                        "contains": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "pattern": "^file$"
-                                },
-                                "name": {
-                                  "pattern": "^curation_original_\\d+.*\\.json$"
-                                }
-                              }
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "pattern": "^file$"
-                                },
-                                "name": {
-                                  "pattern": "^file_list_original_\\d+.*\\.json$"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        "minContains": 2
                       }
                     }
                   },
@@ -75,10 +45,6 @@
                       },
                       "name": {
                         "pattern": "^DATA$"
-                      },
-                      "contents": {
-                        "type": "array",
-                        "minItems": 0
                       }
                     }
                   },
@@ -90,10 +56,6 @@
                       },
                       "name": {
                         "pattern": "^ORIGINAL_DATA$"
-                      },
-                      "contents": {
-                        "type": "array",
-                        "minItems": 0
                       }
                     }
                   },
@@ -117,7 +79,7 @@
                                   "pattern": "^file$"
                                 },
                                 "name": {
-                                  "pattern": "^Deposit_Agreement.*\\.pdf$"
+                                  "pattern": "^Deposit.Agreement.*\\.pdf$"
                                 }
                               }
                             },


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
Change the json schema to allow more flexibility in the curation packages. Allows more missing files that aren't relevant for preservation, more flexibility in naming of required files

<!-- Add any linked issue(s) -->
Fixes #8 


*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
Run [directory-validate.py](https://github.com/UAL-RE/ReBACH/blob/main/ualrdm-directory-validation/directory-validate.py) on the testing data with the [ualrdm-curationdirectory-schema.json](https://github.com/UAL-RE/ReBACH/blob/main/ualrdm-directory-validation/ualrdm-curationdirectory-schema.json) schema