### PR TITLE
Add post_process_script_function method

### DIFF
--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -832,11 +832,47 @@ class Article:
     Post-processing script command function.
     """
     def post_process_script_function(self):
-        post_process_script_command = self.system_config["post_process_script_command"]
-        if (post_process_script_command != ""):
-            self.logs.write_log_in_file("info", f"Executing post-processing script: {post_process_script_command}.", True)
+        try:
+            args, config = get_args()
+        except TOMLDecodeError as e:
+            self.logs.write_log_in_file('info',f"Error in configuration file: {e.filename}.",True)
+            self.logs.write_log_in_file('info',f"TOML Decode Error: {e}.",True)
+            sys.exit(Status.INVALID_CONFIG)
+
+        log_dir = config['Logging']['log_dir']
+        logfile_prefix = config['Logging']['logfile_prefix']
+
+        log = logger.log_setup(log_dir, logfile_prefix)
+
+        self.logs.write_log_in_file("info",f"Config file: {args.config}",True) 
+    
+        os.environ['WASABI_ACCESS_KEY_ID'] = config['Wasabi']['access_key']
+        os.environ['WASABI_SECRET_ACCESS_KEY'] = config['Wasabi']['secret_key']
+
+        args.path = preservation_package_path
+            
+        preservation_package_name = os.path.basename(preservation_package_path)
+        bagger = Bagger(workflow=args.workflow, output_dir=args.output_dir,
+                 delete=args.delete, dart_command=args.dart_command,
+                 config=config, log=log, overwrite=args.overwrite, dryrun=args.dry_run)
+           
+        if args.batch:
+               self.logs.write_log_in_file("Info", "Batch mode", True)
+               self.logs.write_log_in_file("Info",f" Batch path: {args.path}",True) 
+               for _path in next(os.walk(args.path))[1]:
+                   bagger.run_dart(Path(args.path, _path))
         else:
-            return 0
+                self.logs.write_log_in_file("Info",f"Trying to upload preservation package '{preservation_package_name}' to Wasabi. ",True)
+                status = bagger.run_dart(args.path)      
+                self.logs.write_log_in_file("Info",f"Status: {status.name}.",True)
+                self.logs.write_log_in_file("Info",f"Exit code: {status}.",True)
+                if (status == 0):
+                     self.logs.write_log_in_file("Info",f"Preservation package '{preservation_package_name}' successfully uploaded to Wasabi",True)
+                     return 0
+                elif (status == 3):
+                     return 0
+                else:
+                     return status   
 
     """
     Delete folder


### PR DESCRIPTION
Previously, there was no definition for the post_process_script_function method. This commit adds the method to the codebase, which allows for post-processing scripts to be run on preservation packages. The method takes two parameters: the path to the preservation package and the result code of the pre-processing script.