### PR TITLE
Fix Issue #36 - Incorrect metadata directory and filename

### DIFF
--- a/bagger/bag.py
+++ b/bagger/bag.py
@@ -95,11 +95,11 @@ class Bagger:
         bag_name = f'{package_name}.tar'
 
         article_id, version, metadata_hash = self.decompose_name(package_name)
-        metadata_dir = f'v{version}/METADATA/'
-        metadata_filename = f'preservation_final_{article_id}.json'
+        metadata_dir = f'{version}/METADATA/'
+        metadata_filename = f'{article_id}.json'
         metadata_path = Path(package_path, metadata_dir, metadata_filename)
 
-        if not Path(package_path).exists():
+        if not metadata_path.exists():
             return Status.INVALID_PATH
 
         folder_to_list = f"s3://{self.config['Wasabi']['bucket']}"

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -561,7 +561,7 @@ class Article:
 
         return process_article
 
-    def __get_single_file_hash(filepath):
+    def __get_single_file_hash(self, filepath):
         """
         Calculates the has of the given file. Calculation is chunked to save memory
         :param filepath string

--- a/figshare/Integration.py
+++ b/figshare/Integration.py
@@ -57,7 +57,7 @@ class Integration:
             preservation_package_name = os.path.basename(preservation_package_path)
             bagger = Bagger(workflow=args.workflow, output_dir=args.output_dir,
                             delete=args.delete, dart_command=args.dart_command,
-                            config=config, log=log, overwrite=args.overwrite, dryrun=args.dry_run)
+                            config=config, log=log, overwrite=args.overwrite, dryrun=False)
 
             if args.batch:
                 self.logs.write_log_in_file("Info", "Batch mode", True)

--- a/figshare/Integration.py
+++ b/figshare/Integration.py
@@ -65,12 +65,12 @@ class Integration:
                 for _path in next(os.walk(args.path))[1]:
                     bagger.run_dart(Path(args.path, _path))
             else:
-                self.logs.write_log_in_file("Info", f"Trying to upload preservation package '{preservation_package_name}' to Wasabi. ", True)
+                self.logs.write_log_in_file("Info", f"Processing preservation package '{preservation_package_name}' ", True)
                 status = bagger.run_dart(args.path)
                 self.logs.write_log_in_file("Info", f"Status: {status.name}.", True)
                 self.logs.write_log_in_file("Info", f"Exit code: {status}.", True)
                 if (status == 0):
-                    self.logs.write_log_in_file("Info", f"Preservation package '{preservation_package_name}' successfully uploaded to Wasabi", True)
+                    self.logs.write_log_in_file("Info", f"Preservation package '{preservation_package_name}' processed successfully", True)
                     return 0
                 elif (status == 3):
                     return 0


### PR DESCRIPTION
This pull request contains code that fixes the bug #36 

1. The variable 'version' holds the value 'v01'. Therefore, adding 'v' would result in 'vv01'. To correct this, the redundant 'v' is removed.
2. In the preservation staging storage, the metadata filename does not have the phrase 'preservation_final_'. Hence 'preservation_final_' is removed.
3. Updated if condition to check if the file or directory specified by metadata_path exist or not.
4. Update the 'dryrun' parameter to 'False' to override the behavior specified by the @dryable(dry_return=('', '', Status.DRY_RUN)) decorator in the job.py file. Previously, the decorator indicated that the code should be executed in dry mode. However, by setting 'dryrun' to False, the code will now execute without the dry mode behavior.