### PR TITLE
Fix Issue #33 - Missing first_depositor_full_name in preservation storage folder creation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ ReBACH is run via the command line as outlined in the 'How to Run' section of th
 - Python >= 3.9
 - requests Python library >= 2.18.4
 - Ubuntu >= 20.04
+- Slugify >= 7.0.0
 
 ## Requirements:
 - Figshare organization number

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -8,6 +8,7 @@ import hashlib
 from Log import Log
 from Config import Config
 from figshare.Integration import Integration
+from slugify import slugify
 
 
 class Article:
@@ -769,8 +770,10 @@ class Article:
             for version_data in article_versions_list:
                 if version_data is not None or len(version_data) > 0:
                     version_no = "v" + str(version_data["version"]).zfill(2)
+                    first_depositor_full_name = version_data['authors'][0]['full_name']
+                    formatted_depositor_full_name = slugify(first_depositor_full_name, separator="_", lowercase=False)
                     folder_name = str(version_data["id"]) + "_" + version_no + "_" \
-                        + version_data['authors'][0]['url_name'] + "_" + version_data['version_md5']
+                        + formatted_depositor_full_name + "_" + version_data['version_md5']
 
                     if (version_data["matched"] is True):
                         self.logs.write_log_in_file("info", f"Processing article {article} version {version_data['version']}.", True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.18.4
 redata==0.4.1
 s3cmd==2.3.0
 tomli~=2.0.1 ; python_version < "3.11"
+slugify >= 7.0.0


### PR DESCRIPTION
1. This pull request contains code that fixes the bug #33 
2. Updated code to use 'full_name' instead of 'url_name' for first depositor's full name.
3. Handled unicode characters in the full name.