### PR TITLE
Fix: Add missing option to bagger config (Issue #69)

### DIFF
--- a/bagger/config/default.example.toml
+++ b/bagger/config/default.example.toml
@@ -3,6 +3,7 @@ output_dir = "out"
 workflow = "bagger/config/default_workflow.json"
 dart_command = "dart-runner"
 overwrite = false
+delete = true
 
 [Logging]
 log_dir = "logs"


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
Adds the option `delete` to the bagger config. Set it to True which is the default.

<!-- Add any linked issue(s) -->
Fixes #69 

