### PR TITLE
Feat: Improve Bagit profiles for APTrust (Issue #94)

### DIFF
--- a/bagger/config/default_workflow.json
+++ b/bagger/config/default_workflow.json
@@ -24,13 +24,13 @@
     ],
     "allowFetchTxt": false,
     "bagItProfileInfo": {
-      "bagItProfileIdentifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-v2.0.json",
+      "bagItProfileIdentifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-dart-v2.1.json",
       "bagItProfileVersion": "",
       "contactEmail": "redata@arizona.edu",
       "contactName": "ReDATA Administrator",
       "externalDescription": "BagIt profile for creating bags from ReDATA content. Based on APTrust BagIt profile v2.2.",
       "sourceOrganization": "redata.arizona.edu",
-      "version": "2.0"
+      "version": "2.1"
     },
     "manifestsRequired": [
       "md5"
@@ -183,17 +183,16 @@
         "id": "018c0706-5597-4406-a705-205c608d827f",
         "tagFile": "bag-info.txt",
         "tagName": "Internal-Sender-Identifier",
-        "required": false,
+        "required": true,
         "values": [],
-        "defaultValue": null,
+        "defaultValue": "",
         "userValue": "",
         "help": "A unique identifier for this bag inside your organization.",
         "isBuiltIn": true,
         "isUserAddedFile": false,
         "isUserAddedTag": false,
         "wasAddedForJob": false,
-        "errors": {},
-        "emptyOk": true
+        "errors": {}
       },
       {
         "id": "de2c8f3e-fadb-4811-88a2-83aafa44fb50",

--- a/profiles/redata-bagit-dart-v2.1.json
+++ b/profiles/redata-bagit-dart-v2.1.json
@@ -1,5 +1,5 @@
 {
-	"80dda49d-96c9-46dd-91bf-7f57053854d4": {
+    "80dda49d-96c9-46dd-91bf-7f57053854d4": {
 		"id": "80dda49d-96c9-46dd-91bf-7f57053854d4",
 		"userCanDelete": true,
 		"required": [
@@ -18,13 +18,13 @@
 		],
 		"allowFetchTxt": false,
 		"bagItProfileInfo": {
-			"bagItProfileIdentifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-v2.0.json",
+			"bagItProfileIdentifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-dart-v2.1.json",
 			"bagItProfileVersion": "",
 			"contactEmail": "redata@arizona.edu",
 			"contactName": "ReDATA Administrator",
 			"externalDescription": "BagIt profile for creating bags from ReDATA content. Based on APTrust BagIt profile v2.2.",
 			"sourceOrganization": "redata.arizona.edu",
-			"version": "2.0"
+			"version": "2.1"
 		},
 		"manifestsRequired": [
 			"md5"
@@ -177,17 +177,16 @@
 				"id": "018c0706-5597-4406-a705-205c608d827f",
 				"tagFile": "bag-info.txt",
 				"tagName": "Internal-Sender-Identifier",
-				"required": false,
+				"required": true,
 				"values": [],
-				"defaultValue": null,
+				"defaultValue": "",
 				"userValue": "",
 				"help": "A unique identifier for this bag inside your organization.",
 				"isBuiltIn": true,
 				"isUserAddedFile": false,
 				"isUserAddedTag": false,
 				"wasAddedForJob": false,
-				"errors": {},
-				"emptyOk": true
+				"errors": {}
 			},
 			{
 				"id": "de2c8f3e-fadb-4811-88a2-83aafa44fb50",

--- a/profiles/redata-bagit-v2.1.json
+++ b/profiles/redata-bagit-v2.1.json
@@ -24,13 +24,13 @@
     "*"
   ],
   "BagIt-Profile-Info": {
-    "BagIt-Profile-Identifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-v2.0.json",
+    "BagIt-Profile-Identifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-v2.1.json",
     "BagIt-Profile-Version": "",
     "Contact-Email": "redata@arizona.edu",
     "Contact-Name": "ReDATA Administrator",
     "External-Description": "BagIt profile for creating bags from ReDATA content. Based on APTrust BagIt profile v2.2.",
     "Source-Organization": "redata.arizona.edu",
-    "Version": "2.0"
+    "Version": "2.1"
   },
   "Bag-Info": {
     "Source-Organization": {
@@ -52,7 +52,7 @@
       "required": false
     },
     "Internal-Sender-Identifier": {
-      "required": false
+      "required": true
     },
     "Payload-Oxum": {
       "required": false


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**

- Internal-sender-identifier is now required
- updated version numbers
- set the bagItProfileIdentifier field to the corresponding URL for standard or DART profiles. This means that for the standard profile, the bagItProfileIdentifier  points to `redata-bagit-vxx.json` and for the DART profile it points to `redata-bagit-dart-vxx.json`

<!-- Add any related issues or pull requests -->
Closes #94 

**Documentation Update**

 - [ ] I have updated README.md and other relevant documentation
 - [x] No documentation update is needed

*Implementation Notes*
<!-- Describe quirks, issues, provide external resources,  -->
<!-- Example: The exact commands you ran and their output, screenshots. -->
Tested on 2024-02-06. The Alt ID in APTrust shows the value of internal-sender-identifier (set to the item's DOI). Can use the APTrust API to return only objects with a certain prefix. 