### PR TITLE
Fix: Write Internal-Sender-Identifier to bags (Issue #100)

### DIFF
--- a/bagger/config/default.example.toml
+++ b/bagger/config/default.example.toml
@@ -21,7 +21,7 @@ dart_workflow_hostbucket_override = true
 [Metadata]
 # https://github.com/UAL-RE/ReBACH/blob/12-merge-rebach-bagger/bagger/README.md#metadata
 
-aptrust-info.Title = { tag_path = "title" }
+aptrust-info.Title = { tag_path = "title", strip_html = true }
 aptrust-info.Description = { tag_path = "description", strip_html = true }
 
 bag-info.Contact-Name = "ReDATA Administrator"

--- a/bagger/config/default.example.toml
+++ b/bagger/config/default.example.toml
@@ -26,6 +26,6 @@ aptrust-info.Description = { tag_path = "description", strip_html = true }
 
 bag-info.Contact-Name = "ReDATA Administrator"
 bag-info.Contact-Email = "redata@arizona.edu"
-bag-info.DOI = { tag_path = "doi" }
+bag-info.Internal-Sender-Identifier = { tag_path = "doi" }
 bag-info.License-Name = { tag_path = "license.name" }
 bag-info.Published-Date = { tag_path = "published_date" }

--- a/bagger/config/default_workflow.json
+++ b/bagger/config/default_workflow.json
@@ -24,13 +24,13 @@
     ],
     "allowFetchTxt": false,
     "bagItProfileInfo": {
-      "bagItProfileIdentifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-dart-v2.1.json",
+      "bagItProfileIdentifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-dart-v2.2.json",
       "bagItProfileVersion": "",
       "contactEmail": "redata@arizona.edu",
       "contactName": "ReDATA Administrator",
       "externalDescription": "BagIt profile for creating bags from ReDATA content. Based on APTrust BagIt profile v2.2.",
       "sourceOrganization": "redata.arizona.edu",
-      "version": "2.1"
+      "version": "2.2"
     },
     "manifestsRequired": [
       "md5"
@@ -187,7 +187,7 @@
         "values": [],
         "defaultValue": "",
         "userValue": "",
-        "help": "A unique identifier for this bag inside your organization.",
+        "help": "A unique identifier for this bag inside your organization. For ReDATA, it is the DOI.",
         "isBuiltIn": true,
         "isUserAddedFile": false,
         "isUserAddedTag": false,
@@ -283,21 +283,6 @@
         "isBuiltIn": true,
         "isUserAddedFile": false,
         "isUserAddedTag": false,
-        "wasAddedForJob": false,
-        "errors": {}
-      },
-      {
-        "id": "d2e29c7a-0d33-4e72-8e37-2d994b6bfe9f",
-        "tagFile": "bag-info.txt",
-        "tagName": "DOI",
-        "required": true,
-        "values": [],
-        "defaultValue": "",
-        "userValue": "",
-        "help": "Digital Object Identifier assigned to the item in ReDATA.",
-        "isBuiltIn": false,
-        "isUserAddedFile": false,
-        "isUserAddedTag": true,
         "wasAddedForJob": false,
         "errors": {}
       },

--- a/profiles/redata-bagit-dart-v2.2.json
+++ b/profiles/redata-bagit-dart-v2.2.json
@@ -18,13 +18,13 @@
 		],
 		"allowFetchTxt": false,
 		"bagItProfileInfo": {
-			"bagItProfileIdentifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-dart-v2.1.json",
+			"bagItProfileIdentifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-dart-v2.2.json",
 			"bagItProfileVersion": "",
 			"contactEmail": "redata@arizona.edu",
 			"contactName": "ReDATA Administrator",
 			"externalDescription": "BagIt profile for creating bags from ReDATA content. Based on APTrust BagIt profile v2.2.",
 			"sourceOrganization": "redata.arizona.edu",
-			"version": "2.1"
+			"version": "2.2"
 		},
 		"manifestsRequired": [
 			"md5"
@@ -181,7 +181,7 @@
 				"values": [],
 				"defaultValue": "",
 				"userValue": "",
-				"help": "A unique identifier for this bag inside your organization.",
+				"help": "A unique identifier for this bag inside your organization. For ReDATA, it is the DOI.",
 				"isBuiltIn": true,
 				"isUserAddedFile": false,
 				"isUserAddedTag": false,
@@ -277,21 +277,6 @@
 				"isBuiltIn": true,
 				"isUserAddedFile": false,
 				"isUserAddedTag": false,
-				"wasAddedForJob": false,
-				"errors": {}
-			},
-			{
-				"id": "d2e29c7a-0d33-4e72-8e37-2d994b6bfe9f",
-				"tagFile": "bag-info.txt",
-				"tagName": "DOI",
-				"required": true,
-				"values": [],
-				"defaultValue": "",
-				"userValue": "",
-				"help": "Digital Object Identifier assigned to the item in ReDATA.",
-				"isBuiltIn": false,
-				"isUserAddedFile": false,
-				"isUserAddedTag": true,
 				"wasAddedForJob": false,
 				"errors": {}
 			},

--- a/profiles/redata-bagit-v2.2.json
+++ b/profiles/redata-bagit-v2.2.json
@@ -24,13 +24,13 @@
     "*"
   ],
   "BagIt-Profile-Info": {
-    "BagIt-Profile-Identifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-v2.1.json",
+    "BagIt-Profile-Identifier": "https://raw.githubusercontent.com/UAL-RE/ReBACH/main/profiles/redata-bagit-v2.2.json",
     "BagIt-Profile-Version": "",
     "Contact-Email": "redata@arizona.edu",
     "Contact-Name": "ReDATA Administrator",
     "External-Description": "BagIt profile for creating bags from ReDATA content. Based on APTrust BagIt profile v2.2.",
     "Source-Organization": "redata.arizona.edu",
-    "Version": "2.1"
+    "Version": "2.2"
   },
   "Bag-Info": {
     "Source-Organization": {
@@ -56,9 +56,6 @@
     },
     "Payload-Oxum": {
       "required": false
-    },
-    "DOI": {
-      "required": true
     },
     "License-Name": {
       "required": false,


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
The Bagger default config now writes the DOI to the Internal-Sender-Identifier field

<!-- Add any linked issue(s) -->
Fixes #100 

*Screenshots or additional context*
None

*Testing (if applicable)*
Created a bag and uploaded to APTrust. The Internal-Sender-Identifier (the DOI) shows up as the Alt_ID field in APTrust
