### PR TITLE
Fix: Preservation package check fails when multiple copies of an item are already preserved (Issue 108)

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,7 +216,8 @@ if __name__ == "__main__":
 
     log.write_log_in_file('info',
                           "Total count of articles with fetch error / articles: \t\t\t\t"
-                          + f'{articles_with_error_count} / {published_unpublished_count}',
+                          + f'{articles_with_error_count} / '
+                          + f'{published_articles_count + already_preserved_articles_count + articles_with_error_count}',
                           True)
 
     log.write_log_in_file('info',

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -609,14 +609,19 @@ class Article:
     :return log error and terminate script if required_space greater.
     """
     def check_required_space(self, required_space):
-        self.logs.write_log_in_file("info", "Checking required space, script will stop if there's not enough space.", True)
+        self.logs.write_log_in_file("info", "Checking required space, script might stop if there's not enough space.", True)
         req_space = required_space * (1 + (int(self.system_config["additional_percentage_required"]) / 100))
         preservation_storage_location = self.preservation_storage_location
         memory = shutil.disk_usage(preservation_storage_location)
         available_space = memory.free
         if (req_space > available_space):
+            if self.system_config['continue-on-error'] == "False":
+                self.logs.write_log_in_file('error', "There isn't enough space in storage path."
+                                                 + f"Required space is {req_space} and available space is {available_space}. Aborting...",
+                                            True, True)
             self.logs.write_log_in_file('error', "There isn't enough space in storage path."
-                                                 + f"Required space is {req_space} and available space is {available_space}.", True, True)
+                                        + f"Required space is {req_space} and available space is {available_space}.",
+                                        True)
 
     """
     Checking file hash

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -630,7 +630,7 @@ class Article:
         if (req_space > available_space):
             if self.system_config['continue-on-error'] == "False":
                 self.logs.write_log_in_file('error', "There isn't enough space in storage path."
-                                                 + f"Required space is {req_space} and available space is {available_space}. Aborting...",
+                                            + f"Required space is {req_space} and available space is {available_space}. Aborting...",
                                             True, True)
             self.logs.write_log_in_file('error', "There isn't enough space in storage path."
                                         + f"Required space is {req_space} and available space is {available_space}.",


### PR DESCRIPTION
When multiple copies of a preserved item exist in a remote storage, hash comparison is performed against just one copy during preservation package check (https://github.com/UAL-RE/ReBACH/issues/102) which could lead to an assumption that the eventual preservation package does not exist and the item is sent for processing rather than been skipped.

This PR creates a list of an item's preserved copies hashes if any exist and the current hash is compared against hashes of all existing preserved copies. The item will be skipped if a match is found. A warning will be logged if multiple preserved copies are found for an item.
