### PR TITLE
Bug: Remove artifacts directory created by dart-runner v>0.96 in the directory where bags are placed 

### DIFF
--- a/bagger/bag.py
+++ b/bagger/bag.py
@@ -4,6 +4,7 @@ from os import PathLike
 from pathlib import Path
 from shutil import rmtree
 from typing import Union
+from wsgiref.validate import validator
 
 from figshare.Utils import extract_item_id_only, extract_version_only, extract_metadata_hash_only, check_local_path, compare_hash
 from figshare.Utils import extract_lastname_only, extract_bag_count, extract_bag_date, upload_to_remote, get_preserved_version_hash_and_size
@@ -197,7 +198,13 @@ class Bagger:
                 rmtree(package_artifact)
 
             errors = data_json['packageResult']['errors']
-            errors |= data_json['validationResult']['errors']
+            validation_result = data_json.get('validationResult', data_json.get('validationResults'))
+            if isinstance(validation_result, list):
+                for result in validation_result:
+                    errors |= result['errors']
+            else:
+                errors |= validation_result['errors']
+
             if len(data_json['uploadResults']) > 0:
                 errors |= data_json['uploadResults'][0]['errors']
 

--- a/bagger/bag.py
+++ b/bagger/bag.py
@@ -4,7 +4,6 @@ from os import PathLike
 from pathlib import Path
 from shutil import rmtree
 from typing import Union
-from wsgiref.validate import validator
 
 from figshare.Utils import extract_item_id_only, extract_version_only, extract_metadata_hash_only, check_local_path, compare_hash
 from figshare.Utils import extract_lastname_only, extract_bag_count, extract_bag_date, upload_to_remote, get_preserved_version_hash_and_size

--- a/bagger/bag.py
+++ b/bagger/bag.py
@@ -2,6 +2,7 @@ import json
 from logging import Logger
 from os import PathLike
 from pathlib import Path
+from shutil import rmtree
 from typing import Union
 
 from figshare.Utils import extract_item_id_only, extract_version_only, extract_metadata_hash_only, check_local_path, compare_hash
@@ -189,6 +190,11 @@ class Bagger:
         # TODO: What if not data?
         if data:
             data_json = json.loads(data)
+
+            package_artifact = data_json['packageResult']['filepath'].replace('.tar', '_artifacts')
+            package_artifact = Path(package_artifact)
+            if package_artifact.exists() and package_artifact.is_dir():
+                rmtree(package_artifact)
 
             errors = data_json['packageResult']['errors']
             errors |= data_json['validationResult']['errors']


### PR DESCRIPTION
### Description
`dart-runner` versions greater than 0.96 create an "_artifacts' directory in addition to the .tar file for a bag in the `output_dir`. The "_artifacts" directory contains only the metadata files in .txt format. Compared to `dart-runner 0.96`, the later versions also return a slightly different data structure and keys after successfully processing a bag, thereby creating a `KeyError`. Regardless of the `KeyError`, bags are generated successfully, but bagger reports errors after a run. This PR removes the "_artifacts" folder and fixes the `KeyError`, hence bagger will be able to use `dart-runner 0.96` or greater.

### Fixes
- Remove "_artifacts" directory after creating the .tar file.
- Consider differences in keys and structure returned by different `dart-runner` versions after successfully processing an item.

### Testing (if applicable)
Run ReBACH using `dart-runner 0.97`. The test is passed if .tar file is created and "_artifacts" directory is not in output_dir. Also,  `KeyError`s should not occur.