### PR TITLE
Fix: Sometimes API requests fail but retry doesn't work

### DIFF
--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -75,12 +75,12 @@ class Article:
         if self.api_endpoint[-1] == "/":
             articles_api = self.api_endpoint + "account/institution/articles"
         retries = 1
+        page = 1
         success = False
         article_data = {}
         while not success and retries <= int(self.retries):
             try:
                 # pagination implemented.
-                page = 1
                 page_size = 100
                 page_empty = False
                 self.logs.write_log_in_file("info", f"Page size is {page_size}.", True)
@@ -119,6 +119,7 @@ class Article:
 
             except Exception as e:
                 retries = self.retries_if_error(e, 500, retries)
+                success = False
                 if (retries > self.retries):
                     break
 
@@ -184,6 +185,7 @@ class Article:
                             break
             except requests.exceptions.RequestException as e:
                 retries = self.retries_if_error(e, 500, retries)
+                success = False
                 if (retries > self.retries):
                     break
 

--- a/figshare/Collection.py
+++ b/figshare/Collection.py
@@ -57,10 +57,10 @@ class Collection:
         retries = 1
         success = False
         collection_data = {}
+        page = 1
         while not success and retries <= int(self.retries):
             try:
                 # pagination implemented.
-                page = 1
                 page_size = 100
                 page_empty = False
                 self.logs.write_log_in_file("info", f"Page size is {page_size}.", True)


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
This PR corrects a logical error that hinders retrying when an API request fails during the fetching of items in the preprocessing stage.

<!-- Add any linked issue(s) -->
Fixes #88 

**Testing (if applicable)**
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
See #88 description.