### PR TITLE
Feat: Inspect dart-runner executable

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,6 +82,7 @@ def main():
     figshare_config = config_obj.figshare_config()
     system_config = config_obj.system_config()
     figshare_api_url = figshare_config["url"]
+    check_dart = inspect_dart()
     log = Log(env_file)
     log_location = system_config["logs_location"]
     ingest_staging_storage = system_config["ingest_staging_storage"]
@@ -144,10 +145,10 @@ def main():
                                   + " not be reached or read.",
                                   True, False)
 
-    if inspect_dart() is None:
+    if check_dart is None:
         log.write_log_in_file('warning',
                               "dart-runner executable not found. Bagging will not occur.", True)
-    elif inspect_dart() is False:
+    elif check_dart is False:
         log.write_log_in_file('warning',
                               "dart-runner is not executable or version is lower than 1.0. Bagging will not occur.",
                               True)

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 import argparse
 from version import __version__, __commit__
 from Log import Log
-from figshare.Utils import upload_to_remote, get_archival_staging_storage
+from figshare.Utils import inspect_dart, upload_to_remote, get_archival_staging_storage
 from figshare.Article import Article
 from datetime import datetime
 from Config import Config
@@ -143,6 +143,14 @@ def main():
                                   "The post process script location specified in the config file could"
                                   + " not be reached or read.",
                                   True, False)
+
+    if inspect_dart() is None:
+        log.write_log_in_file('warning',
+                              "dart-runner executable not found. Bagging will not occur.",True)
+    elif inspect_dart() is False:
+        log.write_log_in_file('warning',
+                              "dart-runner is not executable or version is lower than 1.0. Bagging will not occur.",
+                              True)
 
     return config_obj, log
 

--- a/app.py
+++ b/app.py
@@ -146,7 +146,7 @@ def main():
 
     if inspect_dart() is None:
         log.write_log_in_file('warning',
-                              "dart-runner executable not found. Bagging will not occur.",True)
+                              "dart-runner executable not found. Bagging will not occur.", True)
     elif inspect_dart() is False:
         log.write_log_in_file('warning',
                               "dart-runner is not executable or version is lower than 1.0. Bagging will not occur.",

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from figshare.Integration import Integration
 from figshare.Utils import standardize_api_result, sorter_api_result, get_preserved_version_hash_and_size, metadata_to_hash, check_local_path
 from figshare.Utils import compare_hash, check_wasabi, calculate_payload_size, get_article_id_and_version_from_path, stringify_metadata
-from figshare.Utils import format_version, get_folder_name_in_local_storage, upload_to_remote
+from figshare.Utils import format_version, get_folder_name_in_local_storage, upload_to_remote, inspect_dart
 from slugify import slugify
 from requests.adapters import HTTPAdapter, Retry
 
@@ -1048,21 +1048,28 @@ class Article:
                 self.logs.write_log_in_file("info", "Saving json in metadata folder for each version.", True)
                 success = success & self.__save_json_in_metadata(version_data, folder_name)
 
-                # only run the postprocessor if all above steps succeeded
-                if success:
-                    value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
-                    if (value_post_process != 0):
-                        self.logs.write_log_in_file("error",
-                                                    f"{version_data['id']} version {version_data['version']} - Post-processing script failed.",
+                # only run the postprocessor if all above steps succeeded and dart-runner is available
+                if inspect_dart():
+                    if success:
+                        value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
+                        if (value_post_process != 0):
+                            self.logs.write_log_in_file("error",
+                                                        f"{version_data['id']} version {version_data['version']} - Post-processing script failed.",
+                                                        True)
+                            success = False
+                        else:
+                            success = True
+                    else:
+                        self.logs.write_log_in_file("info",
+                                                    f"No further processing for {version_data['id']} version {version_data['version']} due to errors.",
                                                     True)
                         success = False
-                    else:
-                        success = True
                 else:
-                    self.logs.write_log_in_file("info",
-                                                f"No further processing for {version_data['id']} version {version_data['version']} due to errors.",
-                                                True)
                     success = False
+                    self.logs.write_log_in_file("Warning",
+                                                f"dart-runner not available. No bagging for {version_data['id']} version {version_data['version']}",
+                                                True)
+
             else:
                 # if download process has any errors then delete complete folder
                 self.logs.write_log_in_file("info", "Download process had an error so complete folder is being deleted.", True)
@@ -1076,23 +1083,29 @@ class Article:
                 success = False
         else:
             if check_files or copy_files:
-                if success:
-                    # call post process script function for each matched item.
-                    value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
-                    if (value_post_process != 0):
-                        self.logs.write_log_in_file("error",
-                                                    f"{version_data['id']} version {version_data['version']} - Post-processing script failed.",
+                if inspect_dart():
+                    if success:
+                        # call post process script function for each matched item.
+                        value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
+                        if (value_post_process != 0):
+                            self.logs.write_log_in_file("error",
+                                                        f"{version_data['id']} version {version_data['version']} - Post-processing script failed.",
+                                                        True)
+                            success = False
+                        else:
+                            success = True
+                    else:
+                        self.logs.write_log_in_file("info",
+                                                    f"No further processing for {version_data['id']} version {version_data['version']} due to errors.",
                                                     True)
                         success = False
-                    else:
-                        success = True
                 else:
-                    self.logs.write_log_in_file("info",
-                                                f"No further processing for {version_data['id']} version {version_data['version']} due to errors.",
-                                                True)
                     success = False
+                    self.logs.write_log_in_file("Warning",
+                                                f"dart-runner not available. No bagging for {version_data['id']} version {version_data['version']}",
+                                                True)
             else:
-                self.logs.write_log_in_file("error", "Unexpected condidion in final processing. No further actions taken.", True)
+                self.logs.write_log_in_file("error", "Unexpected condition in final processing. No further actions taken.", True)
                 success = False
         return success
 
@@ -1237,10 +1250,16 @@ class Article:
                         else:
                             self.logs.write_log_in_file("error", "Pre-processing script failed. Running post-processing script.", True)
                             # call post process script function for each matched item.
-                            value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
-                            if (value_post_process != 0):
-                                self.logs.write_log_in_file("error", f"{version_data['id']} version {version_data['version']} - "
-                                                            + "Post-processing script failed.", True)
+                            if inspect_dart():
+                                value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
+                                if (value_post_process != 0):
+                                    self.logs.write_log_in_file("error", f"{version_data['id']} version {version_data['version']} - "
+                                                                + "Post-processing script failed.", True)
+                            else:
+                                self.logs.write_log_in_file("Warning",
+                                                            f"dart-runner not available. No bagging for {version_data['id']} "
+                                                            + f"version {version_data['version']}",
+                                                            True)
         return processed_count, self.skipped_items_counts_dict['ap_trust_preserved_versions'], \
             self.skipped_items_counts_dict['wasabi_preserved_versions'], len(self.skipped_items_counts_dict['articles_with_processing_error']), \
             self.skipped_items_counts_dict['articles_versions_with_processing_error']

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -1061,7 +1061,8 @@ class Article:
                             success = True
                     else:
                         self.logs.write_log_in_file("info",
-                                                    f"No further processing for {version_data['id']} version {version_data['version']} due to errors.",
+                                                    f"No further processing for {version_data['id']} version "
+                                                    + f"{version_data['version']} due to errors.",
                                                     True)
                         success = False
                 else:
@@ -1096,7 +1097,8 @@ class Article:
                             success = True
                     else:
                         self.logs.write_log_in_file("info",
-                                                    f"No further processing for {version_data['id']} version {version_data['version']} due to errors.",
+                                                    f"No further processing for {version_data['id']} version "
+                                                    + f"{version_data['version']} due to errors.",
                                                     True)
                         success = False
                 else:

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -1066,7 +1066,7 @@ class Article:
                         success = False
                 else:
                     success = False
-                    self.logs.write_log_in_file("Warning",
+                    self.logs.write_log_in_file("error",
                                                 f"dart-runner not available. No bagging for {version_data['id']} version {version_data['version']}",
                                                 True)
 
@@ -1101,7 +1101,7 @@ class Article:
                         success = False
                 else:
                     success = False
-                    self.logs.write_log_in_file("Warning",
+                    self.logs.write_log_in_file("error",
                                                 f"dart-runner not available. No bagging for {version_data['id']} version {version_data['version']}",
                                                 True)
             else:
@@ -1256,7 +1256,7 @@ class Article:
                                     self.logs.write_log_in_file("error", f"{version_data['id']} version {version_data['version']} - "
                                                                 + "Post-processing script failed.", True)
                             else:
-                                self.logs.write_log_in_file("Warning",
+                                self.logs.write_log_in_file("error",
                                                             f"dart-runner not available. No bagging for {version_data['id']} "
                                                             + f"version {version_data['version']}",
                                                             True)

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -64,6 +64,7 @@ class Article:
                                           'articles_locally_preserved': 0, 'articles_versions_with_processing_error': 0
                                           }
         self.skipped_article_versions = {}
+        self.check_dart = inspect_dart()
         self.processor = Integration(self.config_obj, self.logs)
 
     """
@@ -1049,7 +1050,7 @@ class Article:
                 success = success & self.__save_json_in_metadata(version_data, folder_name)
 
                 # only run the postprocessor if all above steps succeeded and dart-runner is available
-                if inspect_dart():
+                if self.check_dart:
                     if success:
                         value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
                         if (value_post_process != 0):
@@ -1086,7 +1087,7 @@ class Article:
                 success = False
         else:
             if check_files or copy_files:
-                if inspect_dart():
+                if self.check_dart:
                     if success:
                         # call post process script function for each matched item.
                         value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
@@ -1256,7 +1257,7 @@ class Article:
                         else:
                             self.logs.write_log_in_file("error", "Pre-processing script failed. Running post-processing script.", True)
                             # call post process script function for each matched item.
-                            if inspect_dart():
+                            if self.check_dart:
                                 value_post_process = self.processor.post_process_script_function("Article", check_dir, value_pre_process)
                                 if (value_post_process != 0):
                                     self.logs.write_log_in_file("error", f"{version_data['id']} version {version_data['version']} - "

--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -1070,6 +1070,8 @@ class Article:
                     self.logs.write_log_in_file("error",
                                                 f"dart-runner not available. No bagging for {version_data['id']} version {version_data['version']}",
                                                 True)
+                    if self.system_config['continue-on-error'] == "False":
+                        self.logs.write_log_in_file("info", "Aborting execution.", True, True)
 
             else:
                 # if download process has any errors then delete complete folder
@@ -1106,6 +1108,8 @@ class Article:
                     self.logs.write_log_in_file("error",
                                                 f"dart-runner not available. No bagging for {version_data['id']} version {version_data['version']}",
                                                 True)
+                    if self.system_config['continue-on-error'] == "False":
+                        self.logs.write_log_in_file("info", "Aborting execution.", True, True)
             else:
                 self.logs.write_log_in_file("error", "Unexpected condition in final processing. No further actions taken.", True)
                 success = False
@@ -1262,6 +1266,8 @@ class Article:
                                                             f"dart-runner not available. No bagging for {version_data['id']} "
                                                             + f"version {version_data['version']}",
                                                             True)
+                                if self.system_config['continue-on-error'] == "False":
+                                    self.logs.write_log_in_file("info", "Aborting execution.", True, True)
         return processed_count, self.skipped_items_counts_dict['ap_trust_preserved_versions'], \
             self.skipped_items_counts_dict['wasabi_preserved_versions'], len(self.skipped_items_counts_dict['articles_with_processing_error']), \
             self.skipped_items_counts_dict['articles_versions_with_processing_error']

--- a/figshare/Collection.py
+++ b/figshare/Collection.py
@@ -43,6 +43,7 @@ class Collection:
                                               'already_preserved_versions': 0, 'wasabi_preserved_versions': 0,
                                               'ap_trust_preserved_versions': 0
                                               }
+        self.check_dart = inspect_dart()
         self.processor = Integration(self.config_obj, self.logs)
 
     """
@@ -371,7 +372,7 @@ class Collection:
                     self.__save_json_in_metadata(collection, version, folder_name)
                     collection_preservation_path = self.ingest_staging_storage + \
                         os.path.basename(os.path.dirname(os.path.dirname(folder_name)))
-                    if inspect_dart():
+                    if self.check_dart:
                         value_post_process = self.processor.post_process_script_function("Collection", collection_preservation_path)
                         if (value_post_process != 0):
                             self.logs.write_log_in_file("error", f"collection {collection} - post-processing script failed.", True)

--- a/figshare/Collection.py
+++ b/figshare/Collection.py
@@ -8,6 +8,7 @@ from figshare.Article import Article
 from figshare.Integration import Integration
 from figshare.Utils import standardize_api_result, sorter_api_result, get_preserved_version_hash_and_size, format_version, metadata_to_hash
 from figshare.Utils import compare_hash, check_wasabi, check_local_path, get_folder_name_in_local_storage, upload_to_remote, stringify_metadata
+from figshare.Utils import inspect_dart
 
 
 class Collection:
@@ -370,11 +371,16 @@ class Collection:
                     self.__save_json_in_metadata(collection, version, folder_name)
                     collection_preservation_path = self.ingest_staging_storage + \
                         os.path.basename(os.path.dirname(os.path.dirname(folder_name)))
-                    value_post_process = self.processor.post_process_script_function("Collection", collection_preservation_path)
-                    if (value_post_process != 0):
-                        self.logs.write_log_in_file("error", f"collection {collection} - post-processing script failed.", True)
+                    if inspect_dart():
+                        value_post_process = self.processor.post_process_script_function("Collection", collection_preservation_path)
+                        if (value_post_process != 0):
+                            self.logs.write_log_in_file("error", f"collection {collection} - post-processing script failed.", True)
+                        else:
+                            processed_count += 1
                     else:
-                        processed_count += 1
+                        self.logs.write_log_in_file("Warning",
+                                                    f"dart-runner not available. No bagging for collection {collection}",
+                                                    True)
                 else:
                     self.logs.write_log_in_file("info", "*Dry Run* File download and post-processing with "
                                                 + f"{self.system_config['post_process_script_command']} skipped.", True)

--- a/figshare/Collection.py
+++ b/figshare/Collection.py
@@ -378,7 +378,7 @@ class Collection:
                         else:
                             processed_count += 1
                     else:
-                        self.logs.write_log_in_file("Warning",
+                        self.logs.write_log_in_file("error",
                                                     f"dart-runner not available. No bagging for collection {collection}",
                                                     True)
                 else:

--- a/figshare/Collection.py
+++ b/figshare/Collection.py
@@ -381,6 +381,8 @@ class Collection:
                         self.logs.write_log_in_file("error",
                                                     f"dart-runner not available. No bagging for collection {collection}",
                                                     True)
+                        if self.system_config['continue-on-error'] == "False":
+                            self.logs.write_log_in_file("info", "Aborting execution.", True, True)
                 else:
                     self.logs.write_log_in_file("info", "*Dry Run* File download and post-processing with "
                                                 + f"{self.system_config['post_process_script_command']} skipped.", True)

--- a/figshare/Utils.py
+++ b/figshare/Utils.py
@@ -36,9 +36,9 @@ def inspect_dart() -> Any:
         if int(dart_version.split(" ")[2].replace('v', '')[0]) < 1:
             return False
         return True
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         return None
-    except PermissionError as e:
+    except PermissionError:
         return False
 
 

--- a/figshare/Utils.py
+++ b/figshare/Utils.py
@@ -2,11 +2,44 @@ import requests
 import json
 import os
 import re
+import tempfile
+import configparser
 from typing import Any
 from time import sleep
-import tempfile
+from subprocess import Popen, PIPE
 from bagger.wasabi import Wasabi
-import configparser
+
+
+def inspect_dart() -> Any:
+    """
+    Checks if dart-runner executable exists and it's usable
+
+    :return: Return True if dart-runner executable exists and it's usable
+    :rtype: Any
+    """
+    config = configparser.ConfigParser()
+    config.read('bagger/config/default.toml')
+    default_config = config['Defaults']
+    dart_cmd = default_config['dart_command'].replace('\"', '')
+
+    try:
+        dart_cmd = f'{dart_cmd} --version'
+        dart = Popen(dart_cmd,
+                     shell=True,
+                     stdin=PIPE,
+                     stdout=PIPE,
+                     stderr=PIPE,
+                     text=True,
+                     close_fds=True
+                     )
+        dart_version, _ = dart.communicate()
+        if int(dart_version.split(" ")[2].replace('v', '')[0]) < 1:
+            return False
+        return True
+    except FileNotFoundError as e:
+        return None
+    except PermissionError as e:
+        return False
 
 
 def standardize_api_result(api_result) -> dict:

--- a/figshare/Utils.py
+++ b/figshare/Utils.py
@@ -33,7 +33,9 @@ def inspect_dart() -> Any:
                      close_fds=True
                      )
         dart_version, _ = dart.communicate()
-        if int(dart_version.split(" ")[2].replace('v', '')[0]) < 1:
+        dart_version_re = re.compile("v[0-9]*.")
+        dart_major_version = re.findall(dart_version_re, dart_version)[0].replace('v','').replace(".", "")
+        if int(dart_major_version) < 1:
             return False
         return True
     except FileNotFoundError:

--- a/figshare/Utils.py
+++ b/figshare/Utils.py
@@ -34,7 +34,7 @@ def inspect_dart() -> Any:
                      )
         dart_version, _ = dart.communicate()
         dart_version_re = re.compile("v[0-9]*.")
-        dart_major_version = re.findall(dart_version_re, dart_version)[0].replace('v','').replace(".", "")
+        dart_major_version = re.findall(dart_version_re, dart_version)[0].replace('v', '').replace('.', '')
         if int(dart_major_version) < 1:
             return False
         return True


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR addresses the feature/enhancement. -->
This PR checks the availability of the `dart-runner` executable. It adds a warning to the logs if the `dart-runner` executable is not available or if the version of the `dart-runner` executable is lower than 1. An error is added to the log when an item is not bagged due to the unavailability of `dart-runner`.
<!-- Add any related issues or pull requests -->
See #134 

**Documentation Update**

 - [ ] I have updated README.md and other relevant documentation
 - [x] No documentation update is needed

*Implementation Notes*
<!-- Describe quirks, issues, provide external resources,  -->
<!-- Example: The exact commands you ran and their output, screenshots. -->
- A function to inspect `dart-runner` executable has been added to `Utils.py`
- Check if `dart-runner` executable is available during preliminary checks
- Prevents an attempt to bag any item when `dart-runner` executable is not available.
- Final counts are not modified in this PR since processed items will be 0 if `dart-runner` executable is not available. Only warnings and errors are logged.