### PR TITLE
Bug: Include count of items with missing required files in UAL_RDM in skipped items

### DIFF
--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -1000,6 +1000,13 @@ class Article:
             self.logs.write_log_in_file("error", f"{version_data['id']} version {version_data['version']} - UAL_RDM directory doesn't have required "
                                         + "files in curation storage. Folder will be deleted.", True)
             copy_files = False
+            if version_data['id'] not in self.skipped_items_counts_dict['articles_with_fetch_error']:
+                self.skipped_items_counts_dict['articles_with_processing_error'].add(version_data['id'])
+            self.skipped_items_counts_dict['articles_versions_with_processing_error'] += 1
+            if str(version_data['id']) not in self.skipped_article_versions.keys():
+                self.skipped_article_versions[str(version_data['id'])] = set()
+            self.skipped_article_versions[str(version_data['id'])].add(format_version(version_data['version']))
+
         else:
             self.logs.write_log_in_file("info", "Curation files exist. Continuing execution.", True)
             copy_files = True


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
This PR captures the count of items that have required files missing, such as "Deposit_Agreement.pdf" in `UAL_RDM` directory, as part of the count of items that are skipped due to a fetch error.

<!-- Add any linked issue(s) -->
Fixes #140. 

*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->

*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
- Run ReBACH as in #140. 
- Observe the count.