### PR TITLE
Bug: Check if folder_strucuture key exists in API result.

### DIFF
--- a/figshare/Article.py
+++ b/figshare/Article.py
@@ -539,7 +539,8 @@ class Article:
 
                     folder_for_file = ''
                     # if an item version has no folders, folders dict will be empty
-                    if len(version_data['folder_structure'].keys()) > 0 and str(file['id']) in version_data['folder_structure'].keys():
+                    if 'folder_structure' in version_data.keys() and len(version_data['folder_structure'].keys()) > 0 and \
+                            str(file['id']) in version_data['folder_structure'].keys():
                         folder_for_file = version_data['folder_structure'][str(file['id'])]
                     filepath = os.path.join(article_folder_path, folder_for_file)
                     if not os.path.exists(filepath):
@@ -760,7 +761,8 @@ class Article:
                 self.logs.write_log_in_file('info', "Comparing Figshare file hashes against existing local files.", True)
                 for file in files:
                     # if an item version has no folders, folders dict will be empty
-                    if len(version_data['folder_structure'].keys()) > 0 and str(file['id']) in version_data['folder_structure'].keys():
+                    if 'folder_structure' in version_data.keys() and len(version_data['folder_structure'].keys()) > 0 and \
+                            str(file['id']) in version_data['folder_structure'].keys():
                         folder_for_file = version_data['folder_structure'][str(file['id'])]
                     else:
                         folder_for_file = ''


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
This PR checks if the `folder_structure` key exists in the API results for an item before retrieving it.

<!-- Add any linked issue(s) -->
Fixes #141 

*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->

*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
- Try to reproduce the issue as in #141 and observe if a key error occurs.